### PR TITLE
[#11] Integrate policies in Portuguese Brazil

### DIFF
--- a/airsoftcalculator/fr/politiquedeconfidentialite.html
+++ b/airsoftcalculator/fr/politiquedeconfidentialite.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/airsoftcalculator/pt-BR/contatosuporte.html
+++ b/airsoftcalculator/pt-BR/contatosuporte.html
@@ -1,35 +1,35 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="pt-BR">
   <head>
     <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-              integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
-              crossorigin="anonymous">
-          <link rel="stylesheet" href="../css/base.css">
-            <title>Support Client - AirsoftCalculator</title>
-            <link rel="icon" href="../images/icons/AirsoftCalculator.png">
-            </head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+          crossorigin="anonymous">
+    <link rel="stylesheet" href="../css/base.css">
+    <title>Suporte ao Cliente - AirsoftCalculator</title>
+    <link rel="icon" href="../images/icons/AirsoftCalculator.png">
+  </head>
   <body>
     <div class="site-content d-flex flex-column">
       <header class="navbar navbar-expand-md" style="background-color: #529492;">
         <span class="navbar-brand" href="#">
-          <img src="../images/logos/AirsoftCalculator.png" height="40" alt="AirsoftCalculator logo"> AirsoftCalculator
+          <img src="../images/logos/AirsoftCalculator.png" height="40" alt="Logotipo do AirsoftCalculator"> AirsoftCalculator
         </span>
       </header>
       <main class="container mt-3 flex-grow-1">
         <br>
         <section>
-          <h3>Support Client</h3>
+          <h3>Suporte ao Cliente</h3>
           <article>
-            <p>Pour toute question, problème ou retour, veuillez nous contacter à:</p>
+            <p>Para dúvidas, problemas ou feedback, entre em contato conosco em:</p>
             <p><a href="mailto:contact@airsoftcalculator.eu" class="support-email">contact@airsoftcalculator.eu</a></p>
           </article>
         </section>
         <br>
       </main>
       <footer class="page-footer" style="background-color: #529492;">
-        <div class="footer-content text-center py-3">Copyright © 2019 - Roland Lariotte. All rights reserved.
+        <div class="footer-content text-center py-3">Copyright © 2019 - Roland Lariotte. Todos os direitos reservados.
         </div>
       </footer>
     </div>

--- a/airsoftcalculator/pt-BR/politicadeprivacidade.html
+++ b/airsoftcalculator/pt-BR/politicadeprivacidade.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+          crossorigin="anonymous">
+    <link rel="stylesheet" href="../css/base.css">
+    <title>Política de Privacidade - AirsoftCalculator</title>
+    <link rel="icon" href="../images/icons/AirsoftCalculator.png">
+  </head>
+  <body>
+    <div class="site-content d-flex flex-column">
+      <header class="navbar navbar-expand-md" style="background-color: #529492;">
+        <span class="navbar-brand" href="#">
+          <img src="../images/logos/AirsoftCalculator.png" height="40" alt="Logotipo do AirsoftCalculator"> AirsoftCalculator
+        </span>
+      </header>
+      <main class="container mt-3 flex-grow-1">
+        <br>
+        <h1>Política de Privacidade</h1>
+        <br>
+        <article>
+          <p>AirsoftCalculator ("nós", "nos" ou "nosso") opera o aplicativo móvel AirsoftCalculator (doravante referido como "Serviço").</p>
+          <p>Esta página informa sobre nossas políticas em relação à coleta, uso e divulgação de dados pessoais ao usar nosso Serviço, bem como sobre suas opções relacionadas a esses dados.</p>
+        </article>
+        <br>
+        <section>
+          <h2>Definições</h2>
+          <dl>
+            <dt><strong>Serviço</strong></dt>
+            <dd>Serviço é o aplicativo móvel AirsoftCalculator operado pela AirsoftCalculator.</dd>
+            <dt><strong>Dados Pessoais</strong></dt>
+            <dd>Dados Pessoais significam dados sobre um indivíduo vivo que pode ser identificado a partir desses dados (ou a partir desses e de outras informações em nossa posse ou que provavelmente venham a estar em nossa posse).</dd>
+            <dt><strong>Dados de Uso</strong></dt>
+            <dd>Dados de Uso são dados coletados automaticamente, seja gerados pelo uso do Serviço ou pela própria infraestrutura do Serviço (por exemplo, a duração de uma visita à página).</dd>
+            <dt><strong>Cookies</strong></dt>
+            <dd>Cookies são pequenos arquivos armazenados em seu dispositivo (computador ou dispositivo móvel).</dd>
+            <dt><strong>Controlador de Dados</strong></dt>
+            <dd>Controlador de Dados significa a pessoa natural ou jurídica que (sozinha ou em conjunto com outras pessoas) determina os propósitos para os quais e a maneira pela qual qualquer informação pessoal é, ou será, processada. Para os propósitos desta Política de Privacidade, nós somos um Controlador de Dados dos seus Dados Pessoais.</dd>
+            <dt><strong>Processadores de Dados (ou Provedores de Serviço)</strong></dt>
+            <dd>Processador de Dados (ou Provedor de Serviço) significa qualquer pessoa natural ou jurídica que processa os dados em nome do Controlador de Dados. Podemos usar os serviços de vários Provedores de Serviço para processar seus dados de forma mais eficaz.</dd>
+            <dt><strong>Titular dos Dados (ou Usuário)</strong></dt>
+            <dd>Titular dos Dados é qualquer indivíduo vivo que está utilizando nosso Serviço e é o sujeito dos Dados Pessoais.</dd>
+          </dl>
+        </section>
+        <br>
+        <section>
+          <h2>Coleta e Uso de Informações</h2>
+          <p>Não coletamos nenhum Dado Pessoal, Dados de Uso, nem utilizamos Cookies ou tecnologias de rastreamento similares em nosso Serviço.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Base Legal para o Processamento de Dados Pessoais sob o Regulamento Geral de Proteção de Dados (GDPR)</h2>
+          <p>Se você é do Espaço Econômico Europeu (EEE), observe que, como a AirsoftCalculator não coleta nenhum Dado Pessoal, os requisitos do GDPR em relação à coleta e uso de informações pessoais não são aplicáveis ao nosso Serviço.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Retenção de Dados</h2>
+          <p>A AirsoftCalculator não retém seus Dados Pessoais.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Transferência de Dados</h2>
+          <p>A AirsoftCalculator tomará todas as medidas razoavelmente necessárias para garantir que seus dados sejam tratados de forma segura e de acordo com esta Política de Privacidade e que nenhuma transferência de seus Dados Pessoais ocorra para qualquer organização ou país.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Divulgação de Dados</h2>
+          <p>A AirsoftCalculator não pode divulgar seus Dados Pessoais, pois não coletamos Dados Pessoais.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Segurança dos Dados</h2>
+          <p>A segurança dos seus dados é importante para nós, mas lembre-se de que nenhum método de transmissão pela Internet ou método de armazenamento eletrônico é 100% seguro.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Nossa Política em relação aos Sinais "Do Not Track" sob a Lei de Proteção Online da Califórnia (CalOPPA)</h2>
+          <p>Não suportamos "Do Not Track" ("DNT"). "Do Not Track" é uma preferência que você pode definir no seu navegador da web para informar os sites que você não deseja ser rastreado.</p>
+          <p>Você pode ativar ou desativar "Do Not Track" visitando a página de Preferências ou Configurações do seu navegador da web.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Seus Direitos de Proteção de Dados sob o Regulamento Geral de Proteção de Dados (GDPR)</h2>
+          <p>Se você é residente do Espaço Econômico Europeu (EEE), você tem certos direitos de proteção de dados. No entanto, como a AirsoftCalculator não coleta nenhum Dado Pessoal, esses direitos não se aplicam ao nosso Serviço. Se você acredita que coletamos Dados Pessoais, entre em contato conosco, e abordaremos a situação prontamente.</p>
+          <p>Você tem o direito de reclamar a uma Autoridade de Proteção de Dados sobre nossa coleta e uso de seus Dados Pessoais. Para mais informações, entre em contato com sua autoridade local de proteção de dados no Espaço Econômico Europeu (EEE).</p>
+        </section>
+        <br>
+        <section>
+          <h2>Provedores de Serviço</h2>
+          <p>Podemos empregar empresas e indivíduos de terceiros para facilitar nosso Serviço ("Provedores de Serviço"), fornecer o Serviço em nosso nome ou realizar serviços relacionados ao Serviço. Como não coletamos nenhum Dado Pessoal, esses terceiros não têm acesso a esses dados.</p>
+          <h3>Pagamentos</h3>
+          <p>Oferecemos produtos e/ou serviços pagos dentro do Serviço. Usamos serviços de terceiros para processamento de pagamentos (por exemplo, processadores de pagamento).</p>
+          <p>Embora não coletemos ou armazenemos os detalhes do seu cartão de pagamento, esses detalhes são processados e armazenados diretamente por processadores de pagamento de terceiros, cuja utilização de suas informações pessoais é regida por sua Política de Privacidade. Os processadores de pagamento aderem aos padrões definidos pelo PCI-DSS, conforme administrado pelo Conselho de Padrões de Segurança PCI, que é um esforço conjunto de marcas como Visa, MasterCard, American Express e Discover. Os requisitos do PCI-DSS ajudam a garantir o manuseio seguro das informações de pagamento. Recomendamos que você leia suas políticas de privacidade para entender como suas informações de pagamento são tratadas.</p>
+          <p>O processador de pagamento com quem trabalhamos é:</p>
+          <ul>
+            <li>
+              <p><strong>Pagamentos In-App da Apple Store</strong></p>
+              <p>Sua Política de Privacidade pode ser visualizada em <a href="https://www.apple.com/legal/privacy/en-ww/">https://www.apple.com/legal/privacy/en-ww/</a></p>
+            </li>
+          </ul>
+        </section>
+        <br>
+        <section>
+          <h2>Links para Outros Sites</h2>
+          <p>Nosso Serviço pode conter links para outros sites que não são operados por nós. Se você clicar em um link de terceiros, será direcionado ao site desse terceiro. Recomendamos fortemente que você reveja a Política de Privacidade de cada site que visitar.</p>
+          <p>Não temos controle sobre o conteúdo, as políticas de privacidade ou as práticas de sites ou serviços de terceiros e não assumimos nenhuma responsabilidade por eles.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Privacidade Infantil</h2>
+          <p>Nosso Serviço está aberto a usuários de todas as idades, incluindo crianças. Estamos comprometidos em proteger a privacidade das crianças online. Não coletamos conscientemente informações pessoais de ninguém com menos de 18 anos ("Crianças"). Se você é pai ou responsável e acredita que seu filho nos forneceu informações pessoais, entre em contato conosco, e tomaremos as medidas necessárias para remover essas informações de nossos registros.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Alterações a Esta Política de Privacidade</h2>
+          <p>Podemos atualizar nossa Política de Privacidade de tempos em tempos. Notificaremos você sobre quaisquer alterações postando a nova Política de Privacidade nesta página.</p>
+          <p>Recomenda-se que você revise esta Política de Privacidade periodicamente para quaisquer alterações. As alterações a esta Política de Privacidade são eficazes quando publicadas nesta página.</p>
+        </section>
+        <br>
+        <section>
+          <h2>Contate-Nos</h2>
+          <p>Se você tiver alguma dúvida sobre esta Política de Privacidade, entre em contato conosco:</p>
+          <ul>
+            <li><p><a href="mailto:contact@airsoftcalculator.eu" class="support-email">contact@airsoftcalculator.eu</a></p></li>
+          </ul>
+        </section>
+        <br>
+      </main>
+      <footer class="page-footer" style="background-color: #529492;">
+        <div class="footer-content text-center py-3">Copyright © 2019 - Roland Lariotte. Todos os direitos reservados.
+        </div>
+      </footer>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+            crossorigin="anonymous">
+    </script>
+  </body>
+</html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced French language support for privacy policy and customer support pages.
	- Added new HTML files for Brazilian Portuguese users, including customer support and privacy policy documents.
- **Content Localization**
	- Translated existing English content into French for relevant documents.
	- Ensured new documents are fully localized for Brazilian Portuguese audience, including all necessary information about data practices and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->